### PR TITLE
Properly enumerate devices on Linux

### DIFF
--- a/osu.Framework.Camera/Input/CameraDevice.cs
+++ b/osu.Framework.Camera/Input/CameraDevice.cs
@@ -1,0 +1,8 @@
+namespace osu.Framework.Input
+{
+    public struct CameraDevice
+    {
+        public string Name;
+        public string Path;
+    }
+}

--- a/osu.Framework.Camera/osu.Framework.Camera.csproj
+++ b/osu.Framework.Camera/osu.Framework.Camera.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Framework" Version="2020.819.0"/>
-    <PackageReference Include="DirectShowLib.Standard" Version="1.0.0"/>
     <PackageReference Include="OpenCvSharp4" Version="4.4.0.20200725"/>
+    <PackageReference Include="DirectShowLib.Standard" Version="1.0.0" Condition=" '$(OS)' == 'Windows_NT' "/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #7. As a team decision we're only supporting Linux and Windows for now.
* Windows uses simply uses `DirectShow` to enumerate devices. It provides us it's path and name.
* Linux, we check in the `/dev/` directory. Getting the path is straightforward however for it's name, we check for `/sys/video4linux/` and if it exists, we get the name from there. If not, we'll use its path as its name as a fallback.