### PR TITLE
Modify buffer copy logic; Encode into BMP; Expose Mat buffer into public;

### DIFF
--- a/osu.Framework.Camera/Graphics/Camera/CameraSprite.cs
+++ b/osu.Framework.Camera/Graphics/Camera/CameraSprite.cs
@@ -41,6 +41,7 @@ namespace osu.Framework.Graphics.Camera
         /// </summary>
         public byte[] CaptureData { get; private set; }
 
+        public Mat CaptureBuffer => image;
         public VideoCapture Capture => capture;
         public float FrameWidth => (float)(capture?.FrameWidth);
         public float FrameHeight => (float)(capture?.FrameHeight);
@@ -81,8 +82,20 @@ namespace osu.Framework.Graphics.Camera
                     continue;
                 }
                 
-                CaptureData = image.ToBytes();
-                Texture = Texture.FromStream(new MemoryStream(CaptureData));
+                CaptureData = image.ToBytes(ext:".bmp");
+                using (var stream = new MemoryStream(CaptureData))
+                {
+                    if (Texture != null)
+                    {
+                        //TODO (AINL): Copy RAW memory buffer.
+                        var uploader = new TextureUpload(stream);
+                        Texture.SetData(uploader);
+                    }
+                    else
+                    {
+                        Texture = Texture.FromStream(stream);
+                    }
+                }
                 Colour = Colour4.White;
             }
         }


### PR DESCRIPTION
Modify buffer copy logic; Encode into BMP. Expose Mat buffer into the public.

Buffer copy should be a raw memory copy in later updates. I changed default .png encoding into BMP, and disposing of memory buffers while using Texture creation.

Copy speed improved to 5ms from 20ms. 

CVMat should be public because there will be various OpenCV workload will be required. And CVMat is very useful to change data format and copy buffer for other frameworks.